### PR TITLE
Add invisible backdrop behind active profile menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-profile versions
 
+## 1.6.1
+
+### Added
+
+* Add invisible backdrop behind active profile menu
+
 ## 1.6.0
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-profile",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-profile",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Web component that provides an avatar button and profile menu",
   "module": "dist/myuw-profile.min.mjs",
   "browser": "dist/myuw-profile.min.js",

--- a/src/myuw-profile.html
+++ b/src/myuw-profile.html
@@ -200,17 +200,26 @@
     background-color: #ececec;
   }
 
+  #myuw-profile-backdrop {
+    display: block;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 99;
+  }
+
   /* Don't let `display` styles override hidden attribute */
   [hidden] {
     display: none !important;
   }
-
 </style>
 
 <a href="#" id="myuw-profile-login" hidden>Login</a>
-
+<div id="myuw-profile-backdrop" hidden></div>
 <div id="myuw-profile-wrapper" hidden>
-
   <button id="myuw-profile-circle" aria-label="Profile menu" aria-haspopup="true" aria-controls="myuw-profile-nav"
     aria-expanded="false">
     <p id="myuw-profile-circle-initial"><i class="material-icons">person</i></p>

--- a/src/myuw-profile.js
+++ b/src/myuw-profile.js
@@ -28,6 +28,7 @@ class MyUWProfile extends HTMLElement {
     this.shadowRoot.appendChild(this.constructor.template.content.cloneNode(true));
     this.$login       = this.shadowRoot.getElementById('myuw-profile-login');
     this.$logout      = this.shadowRoot.getElementById('myuw-profile-logout');
+    this.$backdrop    = this.shadowRoot.getElementById('myuw-profile-backdrop');
     this.$button      = this.shadowRoot.getElementById('myuw-profile-circle');
     this.$circle      = this.shadowRoot.getElementById('myuw-profile-circle-initial');
     this.$nav         = this.shadowRoot.getElementById('myuw-profile-nav');
@@ -192,12 +193,14 @@ class MyUWProfile extends HTMLElement {
 
   openMenu() {
     this.$nav.hidden = false;
+    this.$backdrop.hidden=false;
     this.$nav.focus();
     this.$button.setAttribute('aria-expanded', 'true');
   }
 
   closeMenu() {
     this.$nav.hidden = true;
+    this.$backdrop.hidden=true;
     this.$nav.blur();
     this.$button.setAttribute('aria-expanded', 'false');
   }


### PR DESCRIPTION
## 1.6.1

* Add invisible backdrop behind active profile menu

While implementing myuw-profile component in MyUW application, I additionally added a tooltip to the profile button. The issue appeared when I was able to hover the profile button while the profile menu was also open. This was causing the tooltip appearing on top of the menu. I'm adding the backdrop, so that no other elements can hovered when profile menu is active. This is also default behaviour of AngularJS Menu component, which we are currently using on MyUW.
This feature doesn't add any visible changes to the component, but prevents from it.

Issue:
<img width="358" alt="Screen Shot 2020-04-22 at 4 11 15 PM" src="https://user-images.githubusercontent.com/10341961/80034715-792a0c80-84b4-11ea-8ec1-1a85aa649cfe.png">
