### PR TITLE
Decrease the width of profile menu on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-profile versions
 
+## 1.6.2
+
+### Fixed
+
+* Decrease the width of profile menu on smaller screens
+
 ## 1.6.1
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-profile",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-profile",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Web component that provides an avatar button and profile menu",
   "module": "dist/myuw-profile.min.mjs",
   "browser": "dist/myuw-profile.min.js",

--- a/src/myuw-profile.html
+++ b/src/myuw-profile.html
@@ -215,6 +215,12 @@
   [hidden] {
     display: none !important;
   }
+
+  @media only screen and (max-width: 410px) {
+    #myuw-profile-nav {
+      min-width: 230px;
+    }
+  }
 </style>
 
 <a href="#" id="myuw-profile-login" hidden>Login</a>


### PR DESCRIPTION
## 1.6.2

### Fixed

* Decrease the width of profile menu on smaller screens

<img width="386" alt="Screen Shot 2020-05-04 at 1 46 33 PM" src="https://user-images.githubusercontent.com/10341961/81002147-63024180-8e0e-11ea-8889-367ed5f2873e.png">

vs

<img width="358" alt="Screen Shot 2020-05-04 at 1 46 51 PM" src="https://user-images.githubusercontent.com/10341961/81002155-65649b80-8e0e-11ea-9b06-0180fa7679b2.png">
